### PR TITLE
Passing warning.t

### DIFF
--- a/t/warning.t
+++ b/t/warning.t
@@ -17,9 +17,9 @@ my @array = 1, 2, 3;
 # generator function
 my $next = iter @array;
 
-ok ($next( ) ==> assert { warn "Sorry, but the coroutine is dead..." } ==> say);
-ok ($next( ) ==> assert { warn "Sorry, but the coroutine is dead..." } ==> say);
-ok ($next( ) ==> assert { warn "Sorry, but the coroutine is dead..." } ==> say);
-ok ($next( ) ==> assert { warn "Sorry, but the coroutine is dead..." } ==> say);
+ok (assert({ warn "Sorry, but the coroutine is dead..." }, $next).say);
+ok (assert({ warn "Sorry, but the coroutine is dead..." }, $next).say);
+ok (assert({ warn "Sorry, but the coroutine is dead..." }, $next).say);
+ok (assert({ warn "Sorry, but the coroutine is dead..." }, $next).say);
 
 # end of test


### PR DESCRIPTION
s/==> say/==> .say/

The feed operator ==> is not yet implemented for that usage however, so the it has to be written differently (for now)
