### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Coro/Simple.pm
+++ b/lib/Coro/Simple.pm
@@ -2,7 +2,7 @@
 
 use v6;
 
-module Coro::Simple;
+unit module Coro::Simple;
 
 # receives a simple block / pointy block
 sub coro (&block) is export {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.