### PR TITLE
Adapt code to the latest rakudo

### DIFF
--- a/t/transfer.t
+++ b/t/transfer.t
@@ -20,7 +20,7 @@ sub transfer (&generator) {
 # }
 
 # pure 'begin' function
-multi begin (( )) { } # work around ? ...
+multi begin (Bool $) { }
 multi begin (&generator) { begin generator( ) }
 
 my $first;
@@ -52,7 +52,7 @@ $first  = ping "Ping!";
 $second = wtf;
 $third  = pong "Pong!";
 
-ok $first and $second and $third;
+ok $first && $second && $third;
 
 begin $first; # begin the cycle with this generator
 


### PR DESCRIPTION
Otherwise fails with this:

    Cannot unpack or Capture `False`.
    To create a Capture, add parentheses: \(...)
    If unpacking in a signature, perhaps you needlessly used parentheses? -> ($x) {} vs. -> $x {}